### PR TITLE
Return temporary dir name to be cleaned up by the caller

### DIFF
--- a/_examples/ssh-forwardagent/forwardagent.go
+++ b/_examples/ssh-forwardagent/forwardagent.go
@@ -12,7 +12,7 @@ func main() {
 	ssh.Handle(func(s ssh.Session) {
 		cmd := exec.Command("ssh-add", "-l")
 		if ssh.AgentRequested(s) {
-			l, err := ssh.NewAgentListener()
+			l, _, err := ssh.NewAgentListener("")
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/agent.go
+++ b/agent.go
@@ -2,8 +2,8 @@ package ssh
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -35,16 +35,16 @@ func AgentRequested(sess Session) bool {
 
 // NewAgentListener sets up a temporary Unix socket that can be communicated
 // to the session environment and used for forwarding connections.
-func NewAgentListener() (net.Listener, error) {
-	dir, err := ioutil.TempDir("", agentTempDir)
+func NewAgentListener() (net.Listener, string, error) {
+	dir, err := os.MkdirTemp("", agentTempDir)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	l, err := net.Listen("unix", filepath.Join(dir, agentListenFile))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return l, nil
+	return l, dir, nil
 }
 
 // ForwardAgentConnections takes connections from a listener to proxy into the

--- a/agent.go
+++ b/agent.go
@@ -33,12 +33,16 @@ func AgentRequested(sess Session) bool {
 	return sess.Context().Value(contextKeyAgentRequest) == true
 }
 
-// NewAgentListener sets up a temporary Unix socket that can be communicated
-// to the session environment and used for forwarding connections.
-func NewAgentListener() (net.Listener, string, error) {
-	dir, err := os.MkdirTemp("", agentTempDir)
-	if err != nil {
-		return nil, "", err
+// NewAgentListener sets up a temporary Unix socket, if dir is not specified, that can be communicated
+// to the session environment and used for forwarding connections. If dir is specified, it will use the directory
+// to create the socket file.
+func NewAgentListener(dir string) (net.Listener, string, error) {
+	var err error
+	if dir == "" {
+		dir, err = os.MkdirTemp("", agentTempDir)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 	l, err := net.Listen("unix", filepath.Join(dir, agentListenFile))
 	if err != nil {


### PR DESCRIPTION
This PR updates the AgentListener function to accept an optional directory to use instead of a random tmp directory and returns the directory name so it can be cleaned up by the caller